### PR TITLE
Testing

### DIFF
--- a/notebooks/1_advanced_python.ipynb
+++ b/notebooks/1_advanced_python.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "pi = 3.14159265359\n",
-    "print(f\"pi is equal to {pi}\")"
+    "print(f\"pi is equal to {pi}\")\n"
    ]
   },
   {


### PR DESCRIPTION
h = 1
N = 8
order = 2

d2_dx2 = FinDiff(0, h, order)
d2_dx2.matrix((8,)).toarray()

#Challenge 5.2: Look up the documentation for findiff (Hint: Google)
#and provide a sentence or two explaining what the three arguments 
#used above are.

# FinDiff is a general linear differential operator expressed 
# in finite differences.

# The first parameter is the axis along which to take the derivative. 
# Since we want to apply it to the one and only axis of the 1D array, 
# this is a 0. The second parameter is the grid spacing. The third parameter 
# is the derivative order you want (most likely 1 or 2).

# .matrix((N,)).toarray() takes the d2_dx2 and creates a matrix for it 
# of N X N. Then coverts it to an array. 